### PR TITLE
flushing stdout to prevent buffering

### DIFF
--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -138,6 +138,7 @@ class AuthHandler(BaseHTTPRequestHandler):
 
         sys.stdout.write("%s - %s [%s] %s\n" % (addr, user,
                          self.log_date_time_string(), format % args))
+        sys.stdout.flush()
 
     def log_error(self, format, *args):
         self.log_message(format, *args)


### PR DESCRIPTION
Adding stdout flushing to log_message method. This is required because when nginx ldap auth daemon does logging - there is a lag in the logs being dumped to the file because of the buffering done. For users monitoring the nginx ldap auth daemon log file - this prevents them from viewing logs in real time. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
