### PR TITLE
Fix proxy cache key

### DIFF
--- a/nginx-elasticsearch.conf
+++ b/nginx-elasticsearch.conf
@@ -43,7 +43,7 @@ http {
               proxy_cache_valid 200 10m;
 
               # The following directive adds the cookie to the cache key
-              proxy_cache_key "$http_authorization$cookie_nginxauth";
+              proxy_cache_key "$scheme-$host-$proxy_host-$remote_user";
 
               # As implemented in nginx-ldap-auth-daemon.py, the ldap-auth daemon
               # communicates with an OpenLDAP server, passing in the following

--- a/nginx-ldap-auth-daemon.py
+++ b/nginx-ldap-auth-daemon.py
@@ -138,6 +138,7 @@ class AuthHandler(BaseHTTPRequestHandler):
 
         sys.stdout.write("%s - %s [%s] %s\n" % (addr, user,
                          self.log_date_time_string(), format % args))
+        sys.stdout.flush()
 
     def log_error(self, format, *args):
         self.log_message(format, *args)


### PR DESCRIPTION
The current proxy_cache_key is ```proxy_cache_key "$http_authorization$cookie_nginxauth";``` - this means that the basic auth header will be stored as a key in the cache file. As the auth header is base64 encoded and can be easily decoded, this mechanism can be used to harvest passwords. This PR fixes that by using $remote_user in the proxy_cache_key thereby making the key unique and achieving the purpose of not use the password.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
